### PR TITLE
Add support for Python3 and partial support of MultiNest v3.0 with INS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@
 *.a
 *~
 *.pyc
+*.so
 eggbox
 gauss_shell
 obj_detect
-libnest3.so
+tmp
+chains
 build
 dist
 doc/_build

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-PyMultiNest -- Python interface for MultiNest
-==============================================
+PyMultiNest -- Python interface for MultiNest v3
+=================================================
 
 This library provides programmatic access to MultiNest.
 
@@ -13,6 +13,10 @@ http://apemost.sf.net/ ).
 
 The efficient Monte Carlo algorithm for sampling the parameter space is based 
 on nested sampling and the idea of disjoint multi-dimensional ellipse sampling.
+
+MultiNest v3.0 with Importance Nested Sampling (INS) implemented has been released. 
+Read http://arxiv.org/abs/1306.2144 for more details on INS. Please read the MultiNest
+README file before using the INS in MultiNest v3.0.
 
 For the scientific community, where Python is becoming the new lingua franca (luckily),
 I provide an interface to MultiNest.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import, unicode_literals, print_function
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -40,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'pymultinest'
-copyright = u'2012, Johannes Buchner'
+project = 'pymultinest'
+copyright = '2012, Johannes Buchner'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -178,8 +179,8 @@ htmlhelp_basename = 'pymultinestdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'pymultinest.tex', u'pymultinest Documentation',
-   u'Johannes Buchner', 'manual'),
+  ('index', 'pymultinest.tex', 'pymultinest Documentation',
+   'Johannes Buchner', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -211,6 +212,6 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'pymultinest', u'pymultinest Documentation',
-     [u'Johannes Buchner'], 1)
+    ('index', 'pymultinest', 'pymultinest Documentation',
+     ['Johannes Buchner'], 1)
 ]

--- a/multinest_bridge/Makefile
+++ b/multinest_bridge/Makefile
@@ -1,4 +1,8 @@
 
+# Change next the right multinest library name
+# (tipical are: nest3, multinest, multinest_mpi, ...)
+MNESTLIBNAME := multinest
+# MNESTLIBNAME := nest3
 
 CC = gcc
 FC = gfortran
@@ -32,23 +36,27 @@ endif
 
 CFLAGS += -DMULTINEST_CALL=${MULTINEST_CALL}
 
-LINKLIB = ${FC} -shared
-LIBS =  -L$(MULTINEST) -lnest3 -llapack -lpthread
+#LINKLIB = ${FC} -shared
+LINKLIB = ${CC} -shared
+LIBS =  -L$(MULTINEST) -l$(MNESTLIBNAME) -llapack -lpthread
 # sometimes, this is needed:
 # LIBS +=  -lcblas -latlas
 # LIBS +=  -lcblas -lf77blas -latlas
 
 libcnest.so: $(OBJFILES)
 	# 
+	# MNESTLIBNAME preset to '${MNESTLIBNAME}'. Change this according
+	#  to your MultiNest installation.
+	#
 	# MULTINEST set to ${MULTINEST}. 
 	# 
 	# If you didn't set this to the directory where MultiNest 
 	# is compiled, you will receive see this error later:
 	#     OSError: libcnest.so: undefined symbol: __nested_MOD_nestrun
 	#
-	# Checking if libnest3.so is in $$MULTINEST
-	@if [ ! -e ${MULTINEST}/libnest3.so ]; then echo -e "\nERROR:  libnest3.so not found in '$$MULTINEST'. \nERROR:  Set MULTINEST to the directory where MultiNest is, i.e. where you compiled libnest3.so.\nERROR:  manual: http://johannesbuchner.github.com/PyMultiNest/install.html\n"; exit 1; fi
-	# Found.
+	# Checking if lib${MNESTLIBNAME}.so is in $$MULTINEST...
+	@if [ ! -e ${MULTINEST}/lib${MNESTLIBNAME}.so ]; then echo -e "\nERROR:  lib'$$MNESTLIBNAME'.so not found in '$$MULTINEST'. \nERROR:  Set MULTINEST to the directory where MultiNest is, i.e. where you compiled libmultinest.so.\nERROR:  manual: http://johannesbuchner.github.com/PyMultiNest/install.html\n"; exit 1; fi
+	# ...Found!
 	#
 	$(LINKLIB) $(CFLAGS) cnest.c -o libcnest.so $(LIBS)
 	# all done.

--- a/pyapemost/__init__.py
+++ b/pyapemost/__init__.py
@@ -15,9 +15,9 @@ relevant flags  (see the `API documentation <http://apemost.sourceforge.net/doc/
 
 """
 
-
-from run import set_function, MCMC, calibrate_first_chain, calibrate_other_chains, calibrate, run
-from analyse import create_histogram, create_histograms, print_model_probability, model_probability
-from watch import ProgressWatcher
+from __future__ import absolute_import
+from .run import set_function, MCMC, calibrate_first_chain, calibrate_other_chains, calibrate, run
+from .analyse import create_histogram, create_histograms, print_model_probability, model_probability
+from .watch import ProgressWatcher
 
 

--- a/pyapemost/analyse.py
+++ b/pyapemost/analyse.py
@@ -4,6 +4,7 @@ Module for analysing the output of APEMoST
 The output files are in an easy-to-process format, so
 there is no requirement to use a specific set of tools.
 """
+from __future__ import absolute_import, unicode_literals, print_function
 import numpy
 import scipy, scipy.stats
 import numpy
@@ -97,8 +98,8 @@ def print_model_probability(logprob):
 		limits[i] = "%5.1f" % limits[i]
 		limits[i] = " " * (7 - len(limits[i])) + limits[i]
 	
-	print "Model probability ln(p(D|M, I)): [about 10^%.0f] %.5f" % (logprob / scipy.log(10), logprob)
-	print ("""
+	print("Model probability ln(p(D|M, I)): [about 10^%.0f] %.5f" % (logprob / scipy.log(10), logprob))
+	print(("""
 	Table to compare support against other models (Jeffrey):
 
 	   other model     |
@@ -112,7 +113,7 @@ def print_model_probability(logprob):
 		  <%%(very strong)%s   Decisive
 
 	be careful.
-	""" % tuple(['s']*10)) % limits
+	""" % tuple(['s']*10)) % limits)
 
 def model_probability(show=True):
 	"""
@@ -161,8 +162,8 @@ class VisitedAnalyser(object):
 	def load(self):
 		# load data
 		values = []
-		if verbose: print
-		if verbose: print "visualization: loading chains ..."
+		if verbose: print()
+		if verbose: print("visualization: loading chains ...")
 		f = "prob-chain0.dump"
 		if not os.path.exists(f):
 			raise Exception("visualization: chains not available yet.")
@@ -173,7 +174,7 @@ class VisitedAnalyser(object):
 			raise Exception("visualization: chains couldn't be loaded; perhaps no data yet: " + str(e))
 		for p in self.params:
 			f = "%s-chain-0.prob.dump" % p['name']
-			if verbose: print "	loading chain %s" % f
+			if verbose: print("	loading chain %s" % f)
 			if not os.path.exists(f):
 				raise Exception("visualization: chains not available yet.")
 			try:
@@ -182,8 +183,8 @@ class VisitedAnalyser(object):
 				raise Exception("visualization: chains couldn't be loaded; perhaps no data yet: " + str(e))
 			values.append(v)
 		nvalues = min(map(len, values))
-		if verbose: print "visualization: loading chains finished; %d values" % nvalues
-		self.values = map(lambda v: v[:nvalues][-self.nlast::nevery], values)
+		if verbose: print("visualization: loading chains finished; %d values" % nvalues)
+		self.values = [v[:nvalues][-self.nlast::nevery] for v in values]
 		self.probabilities = probabilities[:nvalues][-self.nlast::nevery]
 	
 	def plot_only(self):
@@ -301,7 +302,7 @@ class VisitedPlotter(VisitedAnalyser):
 				if badbins.sum() != 0:
 					z_min = z_sorted[badbins][0]
 					z_mins.append(z_min)
-					contour_sigmas.append(u'%.0f sigma' % s)
+					contour_sigmas.append('%.0f sigma' % s)
 					if s == 1: colors.append("#dddddd")
 					if s == 3: colors.append("#cccccc")
 			
@@ -322,7 +323,7 @@ class VisitedPlotter(VisitedAnalyser):
 	
 	def conditional_plot_before(self, param1, values1, param2, values2):
 		names = (param1['name'],param2['name'])
-		if verbose: print "visualization: creating conditional plot of %s vs %s" % names
+		if verbose: print("visualization: creating conditional plot of %s vs %s" % names)
 		plt.figure(figsize=(5,5))
 		plt.title("%s vs %s" % names)
 	def conditional_plot_after(self, param1, values1, param2, values2):
@@ -341,7 +342,7 @@ class VisitedPlotter(VisitedAnalyser):
 		self.marginal_plot_after(param, values)
 	def marginal_plot_before(self, param, values):
 		name = param['name']
-		if verbose: print "visualization: creating marginal plot of %s" % name
+		if verbose: print("visualization: creating marginal plot of %s" % name)
 		plt.figure(figsize=(5,5))
 		plt.title("%s" % name)
 	def marginal_plot_after(self, param, values):
@@ -376,10 +377,10 @@ class VisitedAllPlotter(VisitedPlotter):
 		plt.figure(figsize=(5*self.nparams,5*self.nparams))
 	
 	def after_plot(self):
-		if verbose: print "visualization: saving output ..."
+		if verbose: print("visualization: saving output ...")
 		plt.savefig(self.outputfiles_basename + "chain0.pdf")
 		plt.close()
-		if verbose: print "visualization: saving output done"
+		if verbose: print("visualization: saving output done")
 	
 	def choose_plot(self, i, j):
 		plt.subplot(self.nparams, self.nparams, self.nparams * j + i + 1)
@@ -389,7 +390,7 @@ class VisitedAllPlotter(VisitedPlotter):
 		i, j = map(self.paramnames.index, names)
 		self.choose_plot(i, j)
 		names = (param1['name'],param2['name'])
-		if verbose: print "visualization: creating conditional plot of %s vs %s" % names
+		if verbose: print("visualization: creating conditional plot of %s vs %s" % names)
 		plt.xlabel(param1['name'])
 		plt.ylabel(param2['name'])
 	def conditional_plot(self, param1, values1, param2, values2, probabilities, **kwargs):
@@ -403,7 +404,7 @@ class VisitedAllPlotter(VisitedPlotter):
 		name = param['name']
 		i = self.paramnames.index(name)
 		thisplot = self.choose_plot(i, i)
-		if verbose: print "visualization: creating marginal plot of %s" % name
+		if verbose: print("visualization: creating marginal plot of %s" % name)
 		plt.xlabel("iteration")
 		plt.ylabel(name)
 	def marginal_plot_after(self, param, values):
@@ -461,7 +462,7 @@ class VisitedWindow(VisitedAnalyser):
 		name = param['name']
 		i = self.paramnames.index(name)
 		thisplot = self.choose_plot(i, i)
-		self.update_plot(thisplot, "progress", xrange(len(values)), values)
+		self.update_plot(thisplot, "progress", range(len(values)), values)
 		plt.xlabel("iteration")
 		plt.ylabel(name)
 		

--- a/pyapemost/run.py
+++ b/pyapemost/run.py
@@ -1,15 +1,15 @@
-
+from __future__ import absolute_import, unicode_literals, print_function
 from ctypes import *
 try:
 	lib = cdll.LoadLibrary('libapemost.so')
 except OSError as e:
 	if e.message == 'libapemost.so: cannot open shared object file: No such file or directory':
-		print
-		print 'ERROR:   Could not load apemost library "libapemost.so"'
-		print 'ERROR:   You have to build it (download APEMoST), and point '
-		print 'ERROR:   the LD_LIBRARY_PATH environment variable to it!'
-		print
-	print e
+		print()
+		print('ERROR:   Could not load apemost library "libapemost.so"')
+		print('ERROR:   You have to build it (download APEMoST), and point ')
+		print('ERROR:   the LD_LIBRARY_PATH environment variable to it!')
+		print()
+	print(e)
 	import sys
 	sys.exit(1)
 

--- a/pyapemost/watch.py
+++ b/pyapemost/watch.py
@@ -1,9 +1,9 @@
 """
 Module for watching the progress of APEMoST
 """
-
+from __future__ import absolute_import, unicode_literals, print_function
 import threading
-import analyse
+from . import analyse
 import matplotlib.pyplot as plt
 import shutil, os
 
@@ -37,7 +37,7 @@ class ProgressWatcher(threading.Thread):
 			try:
 				self._plot_live()
 			except Exception as e:
-				print 'Plotting failed', e
+				print('Plotting failed', e)
 				#import traceback
 				#traceback.print_exc()
 	

--- a/pyapemost_demo.py
+++ b/pyapemost_demo.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import scipy
 import numpy
 import math
@@ -81,15 +82,15 @@ if "analyse" in cmd:
 	i = 1
 	plt.clf()
 	plt.figure(figsize=(7, 4 * len(histograms)))
-	for k,(v,stats) in histograms.iteritems():
+	for k,(v,stats) in histograms.items():
 		plt.subplot(len(histograms), 1, i)
 		plt.plot(v[:,0], v[:,2], ls='steps--', label=k)
 		plt.legend()
-		print k, stats
+		print(k, stats)
 		i = i + 1
 	plt.savefig("marginals.pdf")
 	show("marginals.pdf")
 	
-	print pyapemost.model_probability()
+	print(pyapemost.model_probability())
 
 

--- a/pycuba/__init__.py
+++ b/pycuba/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import ctypes
 from ctypes import POINTER, c_int, c_double, c_void_p, byref
 
@@ -347,15 +348,15 @@ def demo():
   KEY = 0
   
   def print_header(name):
-    print '-------------------- %s test -------------------' % name
+    print('-------------------- %s test -------------------' % name)
   def print_results(name, results):
     keys = ['nregions', 'neval', 'fail']
-    keys = filter(results.has_key, keys)
-    text = map(lambda k: "%s %d" % (k, results[k]), keys)
-    print "%s RESULT:\t" % name.upper() + "\t".join(text)
+    keys = list(filter(results.has_key, keys))
+    text = ["%s %d" % (k, results[k]) for k in keys]
+    print("%s RESULT:\t" % name.upper() + "\t".join(text))
     for comp in results['results']:
-      print "%s RESULT:\t" % name.upper() + \
-	"%(integral).8f +- %(error).8f\tp = %(prob).3f\n" % comp
+      print("%s RESULT:\t" % name.upper() + \
+	"%(integral).8f +- %(error).8f\tp = %(prob).3f\n" % comp)
   
   from os import environ as env
   verbose = 2

--- a/pymultinest/__init__.py
+++ b/pymultinest/__init__.py
@@ -21,13 +21,14 @@ outputfiles_basename is the prefix used for the output files of MultiNest
 (default chains/1-).
 
 """
-from run import run
-from analyse import Analyzer
+from __future__ import absolute_import, unicode_literals, print_function
+from .run import run
+from .analyse import Analyzer
 try:            
-	from watch import ProgressWatcher, ProgressPrinter, ProgressPlotter
-	from plot import PlotMarginal, PlotMarginalModes
+	from .watch import ProgressWatcher, ProgressPrinter, ProgressPlotter
+	from .plot import PlotMarginal, PlotMarginalModes
 except ImportError as e:
-	print e
-	print 'WARNING: no plotting available -- check matplotlib installation and error above'
-	print 'Only MultiNest run capabilities enabled.'
+	print(e)
+	print('WARNING: no plotting available -- check matplotlib installation and error above')
+	print('Only MultiNest run capabilities enabled.')
 

--- a/pymultinest/analyse.py
+++ b/pymultinest/analyse.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import numpy
-from StringIO import StringIO
+from io import StringIO
 import re
 
 def loadtxt2d(intext):
@@ -27,7 +28,7 @@ class Analyzer(object):
 		likelihood & normalized by the evidence.
 		"""
 		self.data_file = "%s.txt" % self.outputfiles_basename
-		print '  analysing data from %s' % self.data_file
+		print(('  analysing data from %s' % self.data_file))
 
 		"""[root]post_separate.dat
 		This file is only created if mmodal is set to T. Posterior 
@@ -66,9 +67,12 @@ class Analyzer(object):
 		return self.equal_weighted_posterior
 	
 	def _read_error_line(self, l):
-		#print '_read_error_line', l
-		name, values = l.split('  ', 1)
+		#print('_read_error_line -> line>', l)
+		name, values = l.split('    ', 1)
+		#print('_read_error_line -> name>', name)
+		#print('_read_error_line -> values>', values)
 		name = name.strip(': ').strip()
+		values = values.strip(': ').strip()
 		v, error = values.split(" +/- ")
 		return name, float(v), float(error)
 	def _read_error_into_dict(self, l, d):
@@ -92,7 +96,7 @@ class Analyzer(object):
 		stats = []
 		
 		for i in range(2, posterior.shape[1]):
-			b = zip(posterior[:,0], posterior[:,i])
+			b = list(zip(posterior[:,0], posterior[:,i]))
 			b.sort(key=lambda x: x[1])
 			b = numpy.array(b)
 			b[:,0] = b[:,0].cumsum()
@@ -142,7 +146,9 @@ class Analyzer(object):
 			information about the modes found:
 			mean, sigma, maximum a posterior in each dimension
 		"""
-		lines = file(self.stats_file).readlines()
+		#lines = file(self.stats_file).readlines()
+		with open(self.stats_file) as file:
+			lines = file.readlines()
 		text = "".join(lines)
 		parts = text.split("\n\n\n")
 		del parts[0]

--- a/pymultinest/plot.py
+++ b/pymultinest/plot.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import numpy
 import scipy
 import scipy.interpolate
@@ -86,7 +87,7 @@ class PlotMarginalModes(object):
 		maxvalue = values.max()
 		
 		# for each grid item, find the matching points and put them in.
-		for row, col in itertools.product(range(len(grid_x)), range(len(grid_y))):
+		for row, col in itertools.product(list(range(len(grid_x))), list(range(len(grid_y)))):
 			if dim2 is not None:
 				xc = grid_x[row,col]
 				here_x = numpy.abs(dim1_column - xc) < binsize1 / 2.
@@ -206,9 +207,9 @@ class PlotMarginalModes(object):
 			z = (x - u) / sigma
 			return 0.5 * (1 + scipy.special.erf(z / numpy.sqrt(2)))
 
-		pdff = lambda x: sum([m['strictly local evidence'] * norm(x,m['mean'][dim1],m['sigma'][dim1]) for m in modes])
+		pdff = lambda x: sum([m['strictly local log-evidence'] * norm(x,m['mean'][dim1],m['sigma'][dim1]) for m in modes])
 		pdf = numpy.vectorize(pdff)(x)
-		cdff = lambda x: sum([m['strictly local evidence'] * normcum(x,m['mean'][dim1],m['sigma'][dim1]) for m in modes])
+		cdff = lambda x: sum([m['strictly local log-evidence'] * normcum(x,m['mean'][dim1],m['sigma'][dim1]) for m in modes])
 		cdf = numpy.vectorize(cdff)(x)
 		
 		if cumulative:
@@ -229,7 +230,7 @@ class PlotMarginalModes(object):
 				break
 			el_xcenter = m['mean'][dim1]
 			el_xsize = 2 * m['sigma'][dim1]
-			el_ysize = m['strictly local evidence']
+			el_ysize = m['strictly local log-evidence']
 			if cumulative:
 				# set to cdf step size
 				y = cdff(el_xcenter)
@@ -299,7 +300,7 @@ class PlotMarginal(object):
 	def plot_marginal(self, dim1, **kwargs):
 		posterior = self.analyser.get_data()
 		
-		b = zip(posterior[:,0], posterior[:,2+dim1])
+		b = list(zip(posterior[:,0], posterior[:,2+dim1]))
 		b.sort(key=lambda x: x[1])
 		b = numpy.array(b)
 		b[:,0] = b[:,0].cumsum()

--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -1,51 +1,51 @@
-
+from __future__ import absolute_import, unicode_literals, print_function
 from ctypes import cdll
 try:
 	lib = cdll.LoadLibrary('libcnest.so')
 except OSError as e:
 	if e.message == 'libcnest.so: cannot open shared object file: No such file or directory':
-		print
-		print 'ERROR:   Could not load MultiNest Bridge library "libcnest.so"'
-		print 'ERROR:   You have to build it (from the multinest_bridge folder in pymultinest),'
-		print 'ERROR:   and point the LD_LIBRARY_PATH environment variable to it!'
-		print 'ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html'
-		print
+		print()
+		print('ERROR:   Could not load MultiNest Bridge library "libcnest.so"')
+		print('ERROR:   You have to build it (from the multinest_bridge folder in pymultinest),')
+		print('ERROR:   and point the LD_LIBRARY_PATH environment variable to it!')
+		print('ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html')
+		print()
 	if e.message == 'libnest3.so: cannot open shared object file: No such file or directory':
-		print
-		print 'ERROR:   Could not load MultiNest library "libnest3.so"'
-		print 'ERROR:   You have to build it (in MultiNest, run make libnest3.so WITHOUT_MPI=1),'
-		print 'ERROR:   and point the LD_LIBRARY_PATH environment variable to it!'
-		print 'ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html'
-		print
+		print()
+		print('ERROR:   Could not load MultiNest library "libnest3.so"')
+		print('ERROR:   You have to build it (in MultiNest, run make libnest3.so WITHOUT_MPI=1),')
+		print('ERROR:   and point the LD_LIBRARY_PATH environment variable to it!')
+		print('ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html')
+		print()
 	if 'undefined symbol: mpi_' in e.message:
-		print
-		print 'ERROR:   You did something stupid. You tried to compile MultiNest with MPI,'
-		print 'ERROR:   but the MultiNest bridge without MPI, or the other way around.'
-		print 'ERROR:   Decide on one consistent way (no MPI is safe). Either way, you currently'
-		print 'ERROR:   do not have MPI compiled into the library, and it fails to load!'
-		print 'ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html'
-		print
+		print()
+		print('ERROR:   You did something stupid. You tried to compile MultiNest with MPI,')
+		print('ERROR:   but the MultiNest bridge without MPI, or the other way around.')
+		print('ERROR:   Decide on one consistent way (no MPI is safe). Either way, you currently')
+		print('ERROR:   do not have MPI compiled into the library, and it fails to load!')
+		print('ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html')
+		print()
 	if 'libcnest.so: undefined symbol:' in e.message and 'nestrun' in e.message:
-		print
-		print 'ERROR:   Sorry.'
-		print 'ERROR:   The compiler decided to call the MultiNest routine differently than we expect.'
-		print 'ERROR:   You have to run $ readelf -s libnest3.so | grep nestrun'
-		print 'ERROR:   to find out how the nestrun routine is called (typically __nested_MOD_nestrun).'
-		print 'ERROR:   Then you have to compile the MultiNest bridge using'
-		print 'ERROR:   $ make clean libcnest.so MULTINEST_CALL=__nested_MOD_nestrun '
-		print 'ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html'
-		print
+		print()
+		print('ERROR:   Sorry.')
+		print('ERROR:   The compiler decided to call the MultiNest routine differently than we expect.')
+		print('ERROR:   You have to run $ readelf -s libnest3.so | grep nestrun')
+		print('ERROR:   to find out how the nestrun routine is called (typically __nested_MOD_nestrun).')
+		print('ERROR:   Then you have to compile the MultiNest bridge using')
+		print('ERROR:   $ make clean libcnest.so MULTINEST_CALL=__nested_MOD_nestrun ')
+		print('ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html')
+		print()
 	# the next if is useless because we can not catch symbol lookup errors (the executable crashes)
 	# but it is still there as documentation.
 	if 'symbol lookup error' in e.message and 'mpi' in e.message:
-		print
-		print 'ERROR:   You are trying to get MPI to run, but MPI failed to load.'
-		print 'ERROR:   Specifically, mpi symbols are missing in the executable.'
-		print 'ERROR:   Let me know if this is a problem of running python or a compilation problem.'
-		print 'ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html'
-		print
+		print()
+		print('ERROR:   You are trying to get MPI to run, but MPI failed to load.')
+		print('ERROR:   Specifically, mpi symbols are missing in the executable.')
+		print('ERROR:   Let me know if this is a problem of running python or a compilation problem.')
+		print('ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html')
+		print()
 	# what if built with MPI, but don't have MPI
-	print e
+	print(e)
 	import sys
 	sys.exit(1)
 
@@ -56,6 +56,7 @@ def run(LogLikelihood,
 	n_dims, 
 	n_params = None, 
 	n_clustering_params = None, wrapped_params = None, 
+	importance_nested_sampling = True,
 	multimodal = True, const_efficiency_mode = False, n_live_points = 1000,
 	evidence_tolerance = 0.5, sampling_efficiency = 0.8, 
 	n_iter_before_update = 100, null_log_evidence = -1e90,
@@ -89,6 +90,10 @@ def run(LogLikelihood,
 	
 	Some of the parameters are explained below. Otherwise consult the 
 	MultiNest documentation.
+	
+	@param importance_nested_sampling:
+		If True, Multinest will use Importance Nested Sampling (INS). Read http://arxiv.org/abs/1306.2144
+		for more details on INS. Please read the MultiNest README file before using the INS in MultiNest v3.0.
 	
 	@param n_params: 
 		Total no. of parameters, should be equal to ndims in most cases 
@@ -186,12 +191,13 @@ def run(LogLikelihood,
 	if dump_callback is not None:
 		lib.set_dumper(dumper_type(dump_wrapper))
 
-	lib.run(c_int(multimodal), c_int(const_efficiency_mode), 
+	lib.run(c_int(importance_nested_sampling),
+		c_int(multimodal), c_int(const_efficiency_mode), 
 		c_int(n_live_points), c_double(evidence_tolerance), 
 		c_double(sampling_efficiency), c_int(n_dims), c_int(n_params),
 		c_int(n_clustering_params), c_int(max_modes), 
 		c_int(n_iter_before_update), c_double(mode_tolerance), 
-		outputfiles_basename, c_int(seed), wraps,
+		create_string_buffer(outputfiles_basename.encode(),100), c_int(seed), wraps,
 		c_int(verbose), c_int(resume), 
 		c_int(write_output), c_int(init_MPI), 
 		c_double(log_zero), c_int(max_iter),

--- a/pymultinest/watch.py
+++ b/pymultinest/watch.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import threading
 
 class ProgressWatcher(threading.Thread):
@@ -46,10 +47,10 @@ class ProgressPrinter(ProgressWatcher):
 			if not self.running:
 				break
 			try:
-				print 'rejected points: ', len(file(self.rejected, 'r').readlines())
-				print 'alive points: ', len(file(self.live, 'r').readlines())
+				print(('rejected points: ', len(file(self.rejected, 'r').readlines())))
+				print(('alive points: ', len(file(self.live, 'r').readlines())))
 			except Exception as e:
-				print e
+				print(e)
 
 class ProgressPlotter(ProgressWatcher):
 	"""
@@ -65,7 +66,7 @@ class ProgressPlotter(ProgressWatcher):
 			try:
 				self._plot_live()
 			except Exception as e:
-				print e
+				print(e)
 	
 	def _plot_live(self):
 		import matplotlib.pyplot as plt

--- a/pymultinest_demo.py
+++ b/pymultinest_demo.py
@@ -1,4 +1,5 @@
-import pymultinest
+from __future__ import absolute_import, unicode_literals, print_function
+import pymultinest as pymn
 import math
 import os, threading, subprocess
 if not os.path.exists("chains"): os.mkdir("chains")
@@ -30,22 +31,24 @@ parameters = ["x", "y"]
 n_params = len(parameters)
 
 # we want to see some output while it is running
-progress = pymultinest.ProgressPlotter(n_params = n_params); progress.start()
+progress = pymn.ProgressPlotter(n_params = n_params); progress.start()
 threading.Timer(2, show, ["chains/1-phys_live.points.pdf"]).start() # delayed opening
 # run MultiNest
-pymultinest.run(myloglike, myprior, n_params, resume = True, verbose = True, sampling_efficiency = 0.3)
+pymn.run(myloglike, myprior, n_params, importance_nested_sampling = False, resume = True, verbose = True, sampling_efficiency = 0.3)
 # ok, done. Stop our progress watcher
 progress.stop()
 
 # lets analyse the results
-a = pymultinest.Analyzer(n_params = n_params)
+a = pymn.Analyzer(n_params = n_params)
 s = a.get_stats()
 
 import json
-json.dump(s, file('%s.json' % a.outputfiles_basename, 'w'), indent=2)
-print
-print "-" * 30, 'ANALYSIS', "-" * 30
-print "Global Evidence:\n\t%.15e +- %.15e" % ( s['global evidence'], s['global evidence error'] )
+#json.dump(s, file('%s.json' % a.outputfiles_basename, 'w'), indent=2)
+with open('%s.json' % a.outputfiles_basename, mode='w') as file:
+	json.dump(s, file, indent=2)
+	print()
+	print("-" * 30, 'ANALYSIS', "-" * 30)
+	print("Global Evidence:\n\t%.15e +- %.15e" % ( s['nested sampling global log-evidence'], s['nested sampling global log-evidence error'] ))
 
 import matplotlib.pyplot as plt
 plt.clf()
@@ -56,7 +59,7 @@ plt.clf()
 
 # Copy and edit this file, and play with it.
 
-p = pymultinest.PlotMarginalModes(a)
+p = pymn.PlotMarginalModes(a)
 plt.figure(figsize=(5*n_params, 5*n_params))
 #plt.subplots_adjust(wspace=0, hspace=0)
 for i in range(n_params):
@@ -72,8 +75,8 @@ for i in range(n_params):
 		plt.xlabel(parameters[i])
 		plt.ylabel(parameters[j])
 
-plt.savefig("marginals_multinest.pdf") #, bbox_inches='tight')
-show("marginals_multinest.pdf")
+plt.savefig("chains/marginals_multinest.pdf") #, bbox_inches='tight')
+show("chains/marginals_multinest.pdf")
 for i in range(n_params):
 	outfile = '%s-mode-marginal-%d.pdf' % (a.outputfiles_basename,i)
 	p.plot_modes_marginal(i, with_ellipses = True, with_points = False)
@@ -89,7 +92,7 @@ for i in range(n_params):
 	plt.savefig(outfile, format='pdf', bbox_inches='tight')
 	plt.close()
 
-print "take a look at the pdf files in chains/" 
+print("Take a look at the pdf files in chains/") 
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except:
 
 setup(
     name = "pymultinest",
-    version = "0.1",
+    version = "0.2",
     description = "Access modules for MultiNest and APEMoST",
     author = "Johannes Buchner",
     author_email = "johannes.buchner.acad [@t] gmx.com",


### PR DESCRIPTION
pyMultiNest is now compatible both with Python 2.6 or higher and
with Python3. With this update, you can run MultiNest v3.0 via
pyMultiNest with the new Importance Nested Sampling (INS) enabled.
At the moment, analysis and plotting of the data generated by
MultiNest v3.0 can be done with pyMultiNest only if INS is disabled.

TESTED: with MultiNest v3.0 (CMAKE version) and under Python 3.3.1
and Python 2.7.5
TO TEST: Python 2.6

On branch master, changes committed:
    modified:   .gitignore
    modified:   README.rst
    modified:   doc/conf.py
    modified:   multinest_bridge/Makefile
    modified:   multinest_bridge/cnest.c
    modified:   pyapemost/**init**.py
    modified:   pyapemost/analyse.py
    modified:   pyapemost/run.py
    modified:   pyapemost/watch.py
    modified:   pyapemost_demo.py
    modified:   pycuba/**init**.py
    modified:   pymultinest/**init**.py
    modified:   pymultinest/analyse.py
    modified:   pymultinest/plot.py
    modified:   pymultinest/run.py
    modified:   pymultinest/watch.py
    modified:   pymultinest_demo.py
    modified:   setup.py
