### PR TITLE
file built-in was removed long time ago

### DIFF
--- a/pymultinest/watch.py
+++ b/pymultinest/watch.py
@@ -47,8 +47,8 @@ class ProgressPrinter(ProgressWatcher):
 			if not self.running:
 				break
 			try:
-				print(('rejected points: ', len(file(self.rejected, 'r').readlines())))
-				print(('alive points: ', len(file(self.live, 'r').readlines())))
+				print(('rejected points: ', len(open(self.rejected, 'r').readlines())))
+				print(('alive points: ', len(open(self.live, 'r').readlines())))
 			except Exception as e:
 				print(e)
 


### PR DESCRIPTION
Substitute `file(...)` for `open(...)`.

This is related to the bug report #35.
