### PR TITLE
Allow for ctypes-based callbacks.

### DIFF
--- a/pycuba/__init__.py
+++ b/pycuba/__init__.py
@@ -34,6 +34,13 @@ integrand_type = ctypes.CFUNCTYPE(c_int, POINTER(c_int),
   POINTER(c_double), POINTER(c_int), POINTER(c_double), c_void_p)
 peakfinder_type = ctypes.CFUNCTYPE(c_void_p, POINTER(c_int), POINTER(BOUNDS), 
   POINTER(c_int), POINTER(c_double))
+
+def wrap_integrand(integrand):
+  use_raw_callback = isinstance(integrand, ctypes._CFuncPtr)
+  if use_raw_callback:
+    return integrand
+  else:
+    return integrand_type(integrand)
   
 def Vegas(integrand, ndim, userdata=NULL, 
     epsrel=EPSREL, epsabs=EPSABS, verbose=0, ncomp=1, seed=None,
@@ -92,7 +99,7 @@ iteration.
   if seed is None:
     seed = 0
   
-  lib.Vegas(ndim, ncomp, integrand_type(integrand), userdata,
+  lib.Vegas(ndim, ncomp, wrap_integrand(integrand), userdata,
     c_int(nvec), c_double(epsrel), c_double(epsabs), verbose, seed,
     mineval, maxeval, nstart, nincrease, nbatch,
     gridno, statefile, spin,
@@ -137,7 +144,7 @@ def Suave(integrand, ndim, nnew=1000, nmin=2, flatness=50., userdata=NULL,
   if seed is None:
     seed = 0
   
-  lib.Suave(ndim, ncomp, integrand_type(integrand), userdata,
+  lib.Suave(ndim, ncomp, wrap_integrand(integrand), userdata,
     c_int(nvec), c_double(epsrel), c_double(epsabs), verbose, seed,
     mineval, maxeval, nnew, nmin, c_double(flatness), statefile, spin,
     byref(nregions), byref(neval), byref(fail), integral, error, prob)
@@ -280,7 +287,7 @@ def Divonne(integrand, ndim,
   if seed is None:
     seed = 0
 
-  lib.Divonne(ndim, ncomp, integrand_type(integrand), userdata,
+  lib.Divonne(ndim, ncomp, wrap_integrand(integrand), userdata,
     c_int(nvec), c_double(epsrel), c_double(epsabs), verbose, seed,
     mineval, maxeval, key1, key2, key3, maxpass, 
     c_double(border), c_double(maxchisq), c_double(mindeviation), 
@@ -318,7 +325,7 @@ def Cuhre(integrand, ndim,
   if seed is None:
     seed = 0
 
-  lib.Cuhre(ndim, ncomp, integrand_type(integrand), userdata,
+  lib.Cuhre(ndim, ncomp, wrap_integrand(integrand), userdata,
     c_int(nvec), c_double(epsrel), c_double(epsabs), verbose,
     mineval, maxeval, key, statefile, spin,
     byref(nregions), byref(neval), byref(fail), integral, error, prob)


### PR DESCRIPTION
Callbacks from compiled C code or Sympy JIT can be used for faster integrand evaluation.

See the vector_callback branch for Sympy:  https://github.com/markdewing/sympy/tree/vector_callback


Some timings from a simple 3D integral:

nquad w/python callback, time = 0.1216 s
   integral results =  (0.24608765540191072, 1.4434249909731589e-08)
nquad w/jit callback, time = 0.0491 s, speedup = 2.48
   integral results =  (0.24608765540191072, 1.4434249909731589e-08)

cubature w/python callback, time = 0.7949 s
cubature w/jit callback, time = 0.0052 s, speedup = 154.35
cubature (vectorized) w/jit callback, time = 0.0052 s, speedup = 152.67

Cuba (Cuhre) w/python callback, time = 0.0064 s
Cuba (Cuhre) w/jit callback, time = 0.0002 s, speedup = 37.96
   integral result =  0.24609025980570043
Cuba (Cuhre) (vectorized) w/jit callback, time = 0.0002 s, speedup = 40.22
  integral result =  0.24609025980570043

Using vectorized callbacks doesn't speed it up much because SIMD vectorization has not been enabled.
The example uses the Cuhre integrator, but the other Cuba integrators work as well.

**Example code:**

```python
from __future__ import print_function

import sympy.printing.llvmjitcode as jit
from sympy import exp
from sympy.abc import x,y,z
from scipy.integrate import nquad
import math
from cubature import cubature
from timeit import timeit
import pycuba


# Sympy expression
e = exp(-2.0*(x*x + y*y + z*z))

# Python version (for nquad)
def f(x,y,z):
    return math.exp(-2.0*(x*x + y*y + z*z))

# Python version (for cubature)
def cf(array):
    x = array[0]
    y = array[1]
    z = array[2]
    return math.exp(-2.0*(x*x + y*y + z*z))

# Python version (for Cuba)
def Integrand(ndim, xx, ncomp, ff, userdata):
    b = 10.0
    x = b*xx[0]
    y = b*xx[1]
    z = b*xx[2]
    
    ff[0] = math.exp(-2.0*(x*x + y*y + z*z))
    return 0

ndim = 3
lim = [0.0, 10.0]
lims = [lim]*ndim
lim_min = [lim[0]]*ndim
lim_max = [lim[1]]*ndim
jacobian = lim[1]**3

# ---------------------
# Scipy.integrate.nquad
# ---------------------

# Python callback
def run_nquad():
    global python_nquad_res
    python_nquad_res = nquad(f, lims)
nquad_time = timeit(stmt=run_nquad, number=1)
print('nquad w/python callback, time = %.4f s'%nquad_time)
print('   integral results = ',python_nquad_res)

# JIT compiled callback
e_scipy = jit.llvm_callable([x,y,z], e, callback_type='scipy.integrate')
def run_nquad_jit():
    global nquad_res
    nquad_res = nquad(e_scipy, lims)
nquad_time_jit = timeit(stmt=run_nquad_jit, number=1)
print('nquad w/jit callback, time = %.4f s, speedup = %.2f'%(nquad_time_jit,nquad_time/nquad_time_jit))
print('   integral results = ',nquad_res)


# --------
# Cubature
# --------

# Python callback
def run_cubature():
    cubature(cf, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time = timeit(stmt=run_cubature, number=1)
print('cubature w/python callback, time = %.4f s'%cubature_time)

# Number timeit evals for JIT code
neval = 100

# JIT compiled callback
e_cub = jit.llvm_callable([x,y,z], e, callback_type='cubature')
def run_cubature_jit():
    cubature(e_cub, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time_jit = timeit(stmt=run_cubature_jit, number=neval)
print('cubature w/jit callback, time = %.4f s, speedup = %.2f'%(cubature_time_jit/neval, neval*cubature_time/cubature_time_jit))


# JIT compiled callback (vectorized)
e_cub = jit.llvm_callable([x,y,z], e, callback_type='cubature_v')
def run_cubature_v_jit():
    cubature(e_cub, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max, vectorized=True)
cubature_v_time_jit = timeit(stmt=run_cubature_v_jit, number=neval)
print('cubature (vectorized) w/jit callback, time = %.4f s, speedup = %.2f'%(cubature_v_time_jit/neval, neval*cubature_time/cubature_v_time_jit))


# ----
# Cuba
# ----

# Python callback
def run_cuhre():
    res = pycuba.Cuhre(Integrand, ndim=3)

cuhre_time = timeit(stmt=run_cuhre, number=1)
print('Cuba (Cuhre) w/python callback, time = %.4f s'%cuhre_time)

e2 = e.subs({x:10.0*x, y:10.0*y, z:10.0*z})
# JIT compiled callback
e_cuba = jit.llvm_callable([x,y,z], e2, callback_type='cuba')
def run_cuhre_jit():
    global jit_res
    jit_res = pycuba.Cuhre(e_cuba, ndim=3)
cuhre_jit_time = timeit(stmt=run_cuhre_jit, number=neval)
print('Cuba (Cuhre) w/jit callback, time = %.4f s, speedup = %.2f'%(cuhre_jit_time/neval, neval*cuhre_time/cuhre_jit_time))
print('   integral result = ',jit_res['results'][0]['integral']*jacobian)

# JIT compiled callback (vectorized)
e_cuba = jit.llvm_callable([x,y,z], e2, callback_type='cuba_v')
def run_cuhre_v_jit():
    global jit_v_res
    jit_v_res = pycuba.Cuhre(e_cuba, ndim=3, nvec=100)
cuhre_v_jit_time = timeit(stmt=run_cuhre_v_jit, number=neval)
print('Cuba (Cuhre) (vectorized) w/jit callback, time = %.4f s, speedup = %.2f'%(cuhre_v_jit_time/neval, neval*cuhre_time/cuhre_v_jit_time))
print('  integral result = ',jit_res['results'][0]['integral']*jacobian)
```