### PR TITLE
fix deprecated BaseException.message attribute

### DIFF
--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -19,21 +19,21 @@ libname += {
 try:
 	lib = cdll.LoadLibrary(libname)
 except OSError as e:
-	if e.message == '%s: cannot open shared object file: No such file or directory' % libname:
+	if str(e) == '%s: cannot open shared object file: No such file or directory' % libname:
 		print()
 		print('ERROR:   Could not load MultiNest library "%s"' % libname)
 		print('ERROR:   You have to build it first,')
 		print('ERROR:   and point the LD_LIBRARY_PATH environment variable to it!')
 		print('ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html')
 		print()
-	if e.message.endswith('cannot open shared object file: No such file or directory'):
+	if str(e).endswith('cannot open shared object file: No such file or directory'):
 		print()
-		print('ERROR:   Could not load MultiNest library: %s' % e.message.split(':')[0])
+		print('ERROR:   Could not load MultiNest library: %s' % str(e).split(':')[0])
 		print('ERROR:   You have to build MultiNest,')
 		print('ERROR:   and point the LD_LIBRARY_PATH environment variable to it!')
 		print('ERROR:   manual: http://johannesbuchner.github.com/PyMultiNest/install.html')
 		print()
-	if 'undefined symbol: mpi_' in e.message:
+	if 'undefined symbol: mpi_' in str(e):
 		print()
 		print('ERROR:   You tried to compile MultiNest linked with MPI,')
 		print('ERROR:   but now when running, MultiNest can not find the MPI linked libraries.')
@@ -41,7 +41,7 @@ except OSError as e:
 		print()
 	# the next if is useless because we can not catch symbol lookup errors (the executable crashes)
 	# but it is still there as documentation.
-	if 'symbol lookup error' in e.message and 'mpi' in e.message:
+	if 'symbol lookup error' in str(e) and 'mpi' in str(e):
 		print()
 		print('ERROR:   You are trying to get MPI to run, but MPI failed to load.')
 		print('ERROR:   Specifically, mpi symbols are missing in the executable.')


### PR DESCRIPTION
This PR fixes the error handling issue in #68 - the `e.message` attribute was deprecated in python 2.6. The library dependency errors are now displayed properly in newer python versions.