### PR TITLE
add option to force *not* running with MPI under MPI context

### DIFF
--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -8,6 +8,7 @@ try: # detect if run through mpiexec/mpirun
 	if MPI.COMM_WORLD.Get_size() > 1: # need parallel capabilities
 		libname = 'libmultinest_mpi'
 except ImportError:
+	MPI = None
 	pass
 
 libname += {
@@ -75,7 +76,8 @@ def run(LogLikelihood,
 	max_modes = 100, mode_tolerance = -1e90,
 	outputfiles_basename = "chains/1-", seed = -1, verbose = False,
 	resume = True, context = 0, write_output = True, log_zero = -1e100, 
-	max_iter = 0, init_MPI = False, dump_callback = None):
+	max_iter = 0, init_MPI = False, dump_callback = None,
+	force_no_MPI=False):
 	"""
 	Runs MultiNest
 	
@@ -170,6 +172,13 @@ def run(LogLikelihood,
 		a callback function for dumping the current status
 	
 	"""
+
+	if MPI and force_no_MPI:
+		libname = 'libmultinest' + {'darwin' : '.dylib',
+									'win32'  : '.dll',
+									'cygwin' : '.dll',
+									}.get(sys.platform, '.so')
+		lib = cdll.LoadLibrary(libname)
 
 	if n_params == None:
 		n_params = n_dims


### PR DESCRIPTION
I have a use case where I am trying to run lots of *serial* multinest runs, each of which is relatively fast, so can easily be done without MPI.  However, as currently implemented, there's no way to do this with pymultinest, since it will automatically try to load the MPI version of multinest if under the MPI context.  So this adds a `force_no_MPI` option, which can be passed to `run`, in which case the vanilla library will load and each MPI instance can happily run in serial.