### PR TITLE
Ctypes to determine the position of the MultiNest library

### DIFF
--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -13,24 +13,11 @@ except ImportError as e:
 	if 'PMIX_RANK' in os.environ:
 		print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
 
-libname += {
-	'darwin' : '.dylib',
-	'win32'  : '.dll',
-	'cygwin' : '.dll',
+libname = {
+	'darwin' : find_library(libname[len('lib'):]),
+	'win32'  : libname+'.dll',
+	'cygwin' : libname+'.dll',
 }.get(sys.platform, '.so')
-
-if sys.platform == 'Darwin':
-	libname = find_library('multinest')
-
-	try: # detect if run through mpiexec/mpirun
-		from mpi4py import MPI
-		if MPI.COMM_WORLD.Get_size() > 1: # need parallel capabilities
-			libname = find_library('multinest_mpi')
-	except ImportError as e:
-		if 'PMIX_RANK' in os.environ:
-			print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
-
-
 
 try:
 	lib = cdll.LoadLibrary(libname)

--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -28,7 +28,7 @@ if sys.platform == 'Darwin':
 			libname = find_library('multinest_mpi')
 	except ImportError as e:
 		if 'PMIX_RANK' in os.environ:
-		print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
+			print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
 
 
 

--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -2,19 +2,27 @@ from __future__ import absolute_import, unicode_literals, print_function
 from ctypes import cdll
 import sys, os
 from ctypes.util import find_library
+import platform
 
-libname = find_library('multinest')
-if libname == None:
-	print("ERROR:   Could not load MultiNest library.")
-	sys.exit(1)
+
+libname = 'libmultinest'
+if platform.system() == 'Darwin': libname = find_library('multinest')
 
 try: # detect if run through mpiexec/mpirun
 	from mpi4py import MPI
 	if MPI.COMM_WORLD.Get_size() > 1: # need parallel capabilities
-		libname = find_library('multinest_mpi')
+		libname = 'libmultinest_mpi'
+		if platform.system() == 'Darwin': libname = find_library('multinest')
 except ImportError as e:
 	if 'PMIX_RANK' in os.environ:
 		print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
+
+if platform.system() != 'Darwin':
+	libname += {
+		'darwin' : '.dylib',
+		'win32'  : '.dll',
+		'cygwin' : '.dll',
+	}.get(sys.platform, '.so')
 
 
 try:

--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -18,7 +18,7 @@ except ImportError as e:
 
 
 try:
-	lib = cdll.LoadLibrary(libname)
+	lib = cdll.LoadLibrary(os.path.abspath(libname))
 except OSError as e:
 	message = str(e)
 	if message == '%s: cannot open shared object file: No such file or directory' % libname:

--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -1,21 +1,21 @@
 from __future__ import absolute_import, unicode_literals, print_function
 from ctypes import cdll
 import sys, os
+from ctypes.util import find_library
 
-libname = 'libmultinest'
+libname = find_library('multinest')
+if libname == None:
+	print("ERROR:   Could not load MultiNest library.")
+	sys.exit(1)
+
 try: # detect if run through mpiexec/mpirun
 	from mpi4py import MPI
 	if MPI.COMM_WORLD.Get_size() > 1: # need parallel capabilities
-		libname = 'libmultinest_mpi'
+		libname = find_library('multinest_mpi')
 except ImportError as e:
 	if 'PMIX_RANK' in os.environ:
 		print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
 
-libname += {
-	'darwin' : '.dylib',
-	'win32'  : '.dll',
-	'cygwin' : '.dll',
-}.get(sys.platform, '.so')
 
 try:
 	lib = cdll.LoadLibrary(libname)

--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -2,27 +2,34 @@ from __future__ import absolute_import, unicode_literals, print_function
 from ctypes import cdll
 import sys, os
 from ctypes.util import find_library
-import platform
 
 
 libname = 'libmultinest'
-if platform.system() == 'Darwin': libname = find_library('multinest')
-
 try: # detect if run through mpiexec/mpirun
 	from mpi4py import MPI
 	if MPI.COMM_WORLD.Get_size() > 1: # need parallel capabilities
 		libname = 'libmultinest_mpi'
-		if platform.system() == 'Darwin': libname = find_library('multinest')
 except ImportError as e:
 	if 'PMIX_RANK' in os.environ:
 		print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
 
-if platform.system() != 'Darwin':
-	libname += {
-		'darwin' : '.dylib',
-		'win32'  : '.dll',
-		'cygwin' : '.dll',
-	}.get(sys.platform, '.so')
+libname += {
+	'darwin' : '.dylib',
+	'win32'  : '.dll',
+	'cygwin' : '.dll',
+}.get(sys.platform, '.so')
+
+if sys.platform == 'Darwin':
+	libname = find_library('multinest')
+
+	try: # detect if run through mpiexec/mpirun
+		from mpi4py import MPI
+		if MPI.COMM_WORLD.Get_size() > 1: # need parallel capabilities
+			libname = find_library('multinest_mpi')
+	except ImportError as e:
+		if 'PMIX_RANK' in os.environ:
+		print("Not using MPI because import mpi4py failed: '%s'. To debug, run python -c 'import mpi4py'.", e)
+
 
 
 try:

--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -26,7 +26,7 @@ if platform.system() != 'Darwin':
 
 
 try:
-	lib = cdll.LoadLibrary(os.path.abspath(libname))
+	lib = cdll.LoadLibrary(libname)
 except OSError as e:
 	message = str(e)
 	if message == '%s: cannot open shared object file: No such file or directory' % libname:


### PR DESCRIPTION
I had issues with the python binder not finding the MultiNest libraries. This change will use the ctypes.util.find_library to find the library file.