### PR TITLE
deprecation removal getargspec -> getfullargspec

### DIFF
--- a/pymultinest/run.py
+++ b/pymultinest/run.py
@@ -209,7 +209,7 @@ def run(LogLikelihood,
 	# check if lnew is supported by user function
 	nargs = 3
 	try:
-		nargs = len(inspect.getargspec(LogLikelihood).args) - inspect.ismethod(LogLikelihood)
+		nargs = len(inspect.getfullargspec(LogLikelihood).args) - inspect.ismethod(LogLikelihood)
 	except:
 		pass
 	


### PR DESCRIPTION
Hi @JohannesBuchner I noticed `PyMultiNest` fails with `Python` 3.11 due to the long-awaited removal of `inspect.getargspec`. This PR just changes that call to `inspect.getfullargspec` and is enough for me to get it running again with `Python` 3.11.